### PR TITLE
README: be more fair with all browser vendors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,19 @@ A few key points:
 * WebAssembly defines an instruction set, intermediate source format (WAST) and a binary encoded format (WASM).
 * WebAssembly has a few higher level features, such as the ability to import and execute outside methods defined via an interface.
 * LLVM includes a WebAssembly backend to generate WASM output.
-* Multiple JIT or interpreted VMs exist for WASM. Major browser JavaScript engines will notably have native support for WebAssembly, including but not limited to: Google's V8 engine (Node.js and Chromium-based browsers), Microsoft's Chakra engine (Microsoft Edge), Mozilla's Spidermonkey engine (Firefox and Thunderbird).
+* Major browser JavaScript engines will notably have native support for
+  WebAssembly, including but not limited to: Google's
+  [V8](https://github.com/v8/v8) engine (Node.js and Chromium-based browsers),
+  Microsoft's [Chakra](https://github.com/Microsoft/ChakraCore) engine
+  (Microsoft Edge), Mozilla's
+  [Spidermonkey](https://github.com/mozilla/gecko-dev/tree/master/js) engine
+  (Firefox and Thunderbird).
+* Other non-browser implementations exist too:
+  [wasm-jit-prototype](https://github.com/WebAssembly/wasm-jit-prototype) (a
+  standalone VM using an LLVM backend),
+  [wabt](https://github.com/WebAssembly/wabt) (a stack-based interpreter),
+  [ml-proto](https://github.com/WebAssembly/spec/tree/master/ml-proto) (the
+  OCaml reference interpreter), etc.
 
 ## What is Ethereum flavored WebAssembly (eWASM)?
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A few key points:
 * WebAssembly defines an instruction set, intermediate source format (WAST) and a binary encoded format (WASM).
 * WebAssembly has a few higher level features, such as the ability to import and execute outside methods defined via an interface.
 * LLVM includes a WebAssembly backend to generate WASM output.
-* Multiple JIT or interpreted VMs exist for WASM. Notably the V8 Javascript engine includes one, which is used in both Node.js and Chrome. Firefox has its own VM implementation.
+* Multiple JIT or interpreted VMs exist for WASM. Major browser JavaScript engines will notably have native support for WebAssembly, including but not limited to: Google's V8 engine (used in both Node.js and Chromium-based browsers), Microsoft's Chakra engine (used in Microsoft Edge), Mozilla's Spidermonkey engine (notably used in Firefox and Thunderbird).
 
 ## What is Ethereum flavored WebAssembly (eWASM)?
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A few key points:
 * WebAssembly defines an instruction set, intermediate source format (WAST) and a binary encoded format (WASM).
 * WebAssembly has a few higher level features, such as the ability to import and execute outside methods defined via an interface.
 * LLVM includes a WebAssembly backend to generate WASM output.
-* Multiple JIT or interpreted VMs exist for WASM. Major browser JavaScript engines will notably have native support for WebAssembly, including but not limited to: Google's V8 engine (used in both Node.js and Chromium-based browsers), Microsoft's Chakra engine (used in Microsoft Edge), Mozilla's Spidermonkey engine (notably used in Firefox and Thunderbird).
+* Multiple JIT or interpreted VMs exist for WASM. Major browser JavaScript engines will notably have native support for WebAssembly, including but not limited to: Google's V8 engine (Node.js and Chromium-based browsers), Microsoft's Chakra engine (Microsoft Edge), Mozilla's Spidermonkey engine (Firefox and Thunderbird).
 
 ## What is Ethereum flavored WebAssembly (eWASM)?
 


### PR DESCRIPTION
Hi there,

The readme as in its current state feels a bit unfair: it makes it feel that only V8 has proper, optimized support for wasm, which is **not** true. Microsoft and [Mozilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1188259) also have VM engines, with different strategies, but all of them including highly optimizing JIT. Apple's Safari support has not been announced in any official statement, although there is some work ongoing in the JSC virtual machine, as shown by this [meta-bug](https://bugs.webkit.org/show_bug.cgi?id=146064). For this reason I have not included JSC in the list, but made it clear that this list was not exhaustive.

Please let me know if you think this needs precisions.

Cheers!