### PR TITLE
[WIP] spec: add `<static>` cell for flagging execution mode

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -60,6 +60,7 @@ The `<callState>` sub-configuration can be saved/restored when needed between ca
         <callState>
           <callDepth>  0     </callDepth>
           <returnData> .List </returnData>
+          <static>     false </static>
 
           <acct>      0        </acct>      // I_a
           <program>   .Program </program>   // I_b


### PR DESCRIPTION
As @pepyakin pointed out, we will need a `<static>` flag for capturing which EEI methods the current execution is allowed to access.

We could also think of implementing this as a `<eeiNamespace>` cell, which contains the list of EEI methods the current execution can access. This nicely encapsulates both the `static` notion, as well as the namespace notion we have discussed for having different methods available to the EVM engines vs the ewasm engines vs the evm2wasm engines.

@chfast and @axic what do you think? Basically, we would have two EVM namespaces, one which is `evm`, and one which is `evm_static`, the second not allowing access to the various EEI methods which cannot be accessed during a `STATICCALL`.