### PR TITLE
Implement the change from eWASM to ewasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Ethereum flavored WebAssembly (eWASM) Design (*Revision 3*)
+# Ethereum flavored WebAssembly (ewasm) Design (*Revision 3*)
 
-This repository contains documents describing the design and high-level overview of eWASM. Expect the contents of this repository to be in flux: everything is still under discussion.
+This repository contains documents describing the design and high-level overview of ewasm. Expect the contents of this repository to be in flux: everything is still under discussion.
 
 ## What is WebAssembly?
 
@@ -26,36 +26,36 @@ A few key points:
   [ml-proto](https://github.com/WebAssembly/spec/tree/master/ml-proto) (the
   OCaml reference interpreter), etc.
 
-## What is Ethereum flavored WebAssembly (eWASM)?
+## What is Ethereum flavored WebAssembly (ewasm)?
 
-eWASM is a restricted subset of WASM to be used for contracts in Ethereum.
+ewasm is a restricted subset of WASM to be used for contracts in Ethereum.
 
-eWASM:
+ewasm:
 * specifies the [VM semantics](./vm_semantics.md)
-* specifies the [semantics for an *eWASM contract*](./contract_interface.md)
-* specifies an [Ethereum environment interface](./eth_interface.md) to facilitate interaction with the Ethereum environment from an *eWASM contract*
+* specifies the [semantics for an *ewasm contract*](./contract_interface.md)
+* specifies an [Ethereum environment interface](./eth_interface.md) to facilitate interaction with the Ethereum environment from an *ewasm contract*
 * specifies [system contracts](./system_contracts.md)
 * specifies [metering](./metering.md) for instructions
 * and aims to restrict [non-deterministic behavior](https://github.com/WebAssembly/design/blob/master/Nondeterminism.md)
 * specifies a backwards compatible upgrade path to EVM1
 
-### Goals of the eWASM project
+### Goals of the ewasm project
 
-* To provide a specification of *eWASM contract* semantics and the *Ethereum interface*
-* To provide an *EVM transpiler*, preferably as an eWASM contract
-* To provide a *metering injector*, preferably as an eWASM contract
-* To provide a VM implementation for executing eWASM contracts
-* To implement an eWASM backend in the Solidity compiler
+* To provide a specification of *ewasm contract* semantics and the *Ethereum interface*
+* To provide an *EVM transpiler*, preferably as an ewasm contract
+* To provide a *metering injector*, preferably as an ewasm contract
+* To provide a VM implementation for executing ewasm contracts
+* To implement an ewasm backend in the Solidity compiler
 * To provide a library and instructions for writing contracts in Rust
 * To provide a library and instructions for writing contracts in C
 
 ### Glossary
 
-* *eWASM contract*: a contract adhering to the eWASM specification
-* *Ethereum environment interface (EEI)*: a set of methods available to eWASM contracts
+* *Ewasm contract*: a contract adhering to the ewasm specification
+* *Ethereum environment interface (EEI)*: a set of methods available to ewasm contracts
 * *metering*: the act of measuring execution cost in a deterministic way
-* *metering injector*: a transformation tool inserting metering code to an eWASM contract
-* *EVM transpiler*: an EVM bytecode (the current Ethereum VM) to eWASM transcompiler
+* *metering injector*: a transformation tool inserting metering code to an ewasm contract
+* *EVM transpiler*: an EVM bytecode (the current Ethereum VM) to ewasm transcompiler
 
 ### Resources
 
@@ -63,7 +63,7 @@ eWASM:
 * [Rationale](./rationale.md)
 * [VM semantics](./vm_semantics.md)
 * [Ethereum environment interface](./eth_interface.md)
-* [eWASM Contract Interface](./contract_interface.md)
+* [Ewasm Contract Interface](./contract_interface.md)
 * [System contracts](./system_contracts.md)
 * [Backwards compatibility instructions](./backwards_compatibility.md)
 * [Original Proposal](https://github.com/ethereum/EIPs/issues/48) (EIP#48)

--- a/backwards_compatibility.md
+++ b/backwards_compatibility.md
@@ -1,15 +1,15 @@
 # Backwards Compatibility
 The current approach to achieving backwards compatibility with EVM1 is to
 support both of the instruction sets with the option to transcompiling EVM1 to 
-eWASM. This approach gives clients optionality when dealing with EVM1 code.
-A client can either implement only an eWASM VM and transcompile all of the EVM1
-code. Or a client can implement a eWASM VM and EVM1 VM and leave the old code as
+ewasm. This approach gives clients optionality when dealing with EVM1 code.
+A client can either implement only an ewasm VM and transcompile all of the EVM1
+code. Or a client can implement a ewasm VM and EVM1 VM and leave the old code as
 is.
 
 ## Gas Prices
-In eWASM we will introduce sub-gas units so that each EVM1 opcode's
-transcompiled equivalent eWASM's gas cost is less then the original EM1 opcode's
-cost. The fee schedule for eWASM is yet to be specified.
+In ewasm we will introduce sub-gas units so that each EVM1 opcode's
+transcompiled equivalent ewasm's gas cost is less then the original EM1 opcode's
+cost. The fee schedule for ewasm is yet to be specified.
 
 ## Identification of code
 We assume there is some sort of code handler function that all clients have 
@@ -19,13 +19,13 @@ starts with WASM's magic number or not.
 The WASM magic number is the following byte sequence: `0x00, 0x61, 0x73, 0x6d`.
 
 ## Solidity
-Support of compiling to eWASM can be accompilshed by adding a new backend to
-the solidity compile. eWASM support for Solidity is part of the MVP.
+Support of compiling to ewasm can be accompilshed by adding a new backend to
+the solidity compile. Ewasm support for Solidity is part of the MVP.
 
 ## Transcompiler
 A post-MVP goal is to have the transcompiler it self become a contract by
-compiling it to eWASM. Once this is accomplished, EVM1 contracts created by 
-the CREATE op will be transcompiled to eWASM. This will also allow us to assume
-that all EVM1 code is now transcompiled eWASM code, which should be reflected
+compiling it to ewasm. Once this is accomplished, EVM1 contracts created by 
+the CREATE op will be transcompiled to ewasm. This will also allow us to assume
+that all EVM1 code is now transcompiled ewasm code, which should be reflected
 in the state root since the has of the code is stored in the Merkle trie. Note:
 this should still allow clients to fallback to EVM1 VMs if running EVM1 code.

--- a/contract_interface.md
+++ b/contract_interface.md
@@ -1,6 +1,6 @@
-# eWASM Contract Interface (ECI) Specification (*Revision 3*)
+# Ewasm Contract Interface (ECI) Specification (*Revision 3*)
 
-The eWASM Contract Interface (ECI) specifies the structure of a contract module.
+The Ewasm Contract Interface (ECI) specifies the structure of a contract module.
 
 ### Wire format
 

--- a/contract_interface.md
+++ b/contract_interface.md
@@ -10,7 +10,7 @@ Every contract must be stored in the [WebAssembly Binary Encoding](https://githu
 
 A contract can only import symbols specified in the [Ethereum Environment Interface or EEI](./eth_interface.md).
 
-In practice, this means that all imports specified by an eWASM module must be from the `ethereum` namespace,
+In practice, this means that all imports specified by an ewasm module must be from the `ethereum` namespace,
 and having a function signature and name directly correspondent to a function specified in the EEI.
 
 As mentioned below, there is a `debug` namespace as well, but that is disallowed in production systems.
@@ -46,7 +46,7 @@ If it needs to abort due to a failure, an *unreachable* instruction should be ex
 
 The use of a [start function](https://webassembly.github.io/spec/core/syntax/modules.html#start-function) is disallowed.
 
-The reason for this is that an eWASM VM would need to have access to the memory space of a contract and that must be acquired prior to executing it.
+The reason for this is that an ewasm VM would need to have access to the memory space of a contract and that must be acquired prior to executing it.
 In the [WebAssembly Javascript API](https://webassembly.org/docs/js/) however the start function is executed right during instantiation, which
 leaves no time for the client to acquire the memory area.
 

--- a/determining_wasm_gas_costs.md
+++ b/determining_wasm_gas_costs.md
@@ -1,7 +1,7 @@
-# Determining eWASM gas costs
+# Determining ewasm gas costs
 
 The goal of this document is to describe the process of determining gas costs
-for eWASM instructions.
+for ewasm instructions.
 
 Each WASM opcode is assigned an appropriate Intel IA-32 (x86) opcode (or a
 series of opcodes). These opcodes have a fixed cycle count (called *latency*
@@ -43,7 +43,7 @@ to at most 64-bits, which results in executing four instructions in the best
 case to match EVM1. Most arithmetic instructions in EVM1 cost 3 gas, which would
 amount to 0.75 gas for most 64-bit WASM instructions.
 
-Internally, eWASM gas measurements should be recorded in a 64 bit variable
+Internally, ewasm gas measurements should be recorded in a 64 bit variable
 with 4 decimal digits precision. We call this *particles*. It is a minor
 implementation detail actually using integers and converting the below gas costs
 appropriately.
@@ -310,7 +310,7 @@ Ternary operator.
 
 ### breaking out of the VM
 
-Any instruction pausing the VM and transferring data between the eWASM contract
+Any instruction pausing the VM and transferring data between the ewasm contract
 and the host is *breaking out of the VM*.
 
 These instructions include:

--- a/eth_interface.md
+++ b/eth_interface.md
@@ -1,6 +1,6 @@
 # Ethereum Environment Interface (EEI) Specification (*Revision 3*)
 
-The Ethereum Environment Interface exposes the core Ethereum API to the eWASM environment. The Ethereum [module](https://github.com/WebAssembly/design/blob/master/Modules.md) will be implemented in the Ethereum client's native language. All parameters and returns are restricted to 32 or 64 bit integers. Floats are disallowed.
+The Ethereum Environment Interface exposes the core Ethereum API to the ewasm environment. The Ethereum [module](https://github.com/WebAssembly/design/blob/master/Modules.md) will be implemented in the Ethereum client's native language. All parameters and returns are restricted to 32 or 64 bit integers. Floats are disallowed.
 
 # Data types
 

--- a/faq.md
+++ b/faq.md
@@ -2,7 +2,7 @@
 
 WASM's FAQ can be found [here](https://github.com/WebAssembly/design/blob/master/FAQ.md) 
 
-## Is eWASM primarily the replacement for EVM?  
+## Is ewasm primarily the replacement for EVM?  
 Currently it is being researched as a replacement instruction set for EVM1. Other instruction sets have been considered but so far WASM seems the most suitable.
 
 ## What are alternatives to WASM?  
@@ -17,16 +17,16 @@ Some that have been considered are [here](./comparison.md)
 ## What is metering?  
 Metering VMs is the same concept as electrical power companies have when charging you for the amount of electricity that you used. With VM's we attempt to get a measurement of computation time of some code and instead of electricity used, you are charged for the CPU's time used. We call this metering.
 
-## Will Solidity/Serpent be compatible with eWASM, or will another HLL have to be created?  
-Not off the bat, a transpiler will have to be created to compile existing EVM code into eWASM. As far as other High level languages you should be able to use a language that can be compiled by LLVM ( c/c++/rust/go)
+## Will Solidity/Serpent be compatible with ewasm, or will another HLL have to be created?  
+Not off the bat, a transpiler will have to be created to compile existing EVM code into ewasm. As far as other High level languages you should be able to use a language that can be compiled by LLVM ( c/c++/rust/go)
 
-## How does eWASM handle non-determinism when a variety of programming languages are allowed to be used?
+## How does ewasm handle non-determinism when a variety of programming languages are allowed to be used?
 Part of the project goal is to eliminate nasal-demons. It's in the MVP. There are still a couple of edge case like sign values on NaNs but they can be canonicalized by AST transforms.  
 
-## Will eWASM be compatible with WASM?  
+## Will ewasm be compatible with WASM?  
 Yes, the Ethereum System Interface can also be written in WASM.
 
-## Can eWASM be built even if WASM is not currently complete or will we need to wait for its completion/MVP?   
+## Can ewasm be built even if WASM is not currently complete or will we need to wait for its completion/MVP?   
 Yes, but we would lose the "Shared tooling" benefit. So It might not make sense.
 
 ## Does eWASM use synchronous or asynchronous methods?

--- a/rationale.md
+++ b/rationale.md
@@ -1,11 +1,11 @@
-## Why do we want eWASM?
+## Why do we want ewasm?
 
 * Fast & Efficient: To truly distinguish Ethereum as the World Computer we need to have a very performant VM. The current architecture of the VM is one of the greatest blockers to raw performance. WebAssembly aims to execute at near native speed by taking advantage of common hardware capabilities available on a wide range of platforms. This will open the door to a wide array of uses that require performance/throughput. 
-* Security: With the add performance gains from eWASM we will be able to implement parts of Ethereum such as the precompiled contract in the VM itself which will minimize our trusted computing base.
+* Security: With the add performance gains from ewasm we will be able to implement parts of Ethereum such as the precompiled contract in the VM itself which will minimize our trusted computing base.
 Standardized Instruction Set: WebAssembly is currently being designed as an open standard by a W3C Community Group and is actively being developed by engineers from Mozilla, Google, Microsoft, and Apple.
 * Toolchain Compatibility: A LLVM front-end for WASM is part of the MVP. This will Allow developers to write contracts and reuse applications written in common languages such as C/C++, go and rust.
-* Portability: WASM is targeted to be deployed in all the major web browsers which will result in it being one of the most widely deployed VM architecture. Contracts compiled to eWASM will share compatibility with any standard WASM environment. Which will make running a program either directly on Ethereum, on a cloud hosting environment, or on one's local machine - a frictionless process.
-* Optional And Flexible Metering: Metering the VM adds overhead but is essential for running untrusted code. If code is trusted then metering maybe optional. eWASM defines metering as an optional layer to accommodate for these use cases.
+* Portability: WASM is targeted to be deployed in all the major web browsers which will result in it being one of the most widely deployed VM architecture. Contracts compiled to ewasm will share compatibility with any standard WASM environment. Which will make running a program either directly on Ethereum, on a cloud hosting environment, or on one's local machine - a frictionless process.
+* Optional And Flexible Metering: Metering the VM adds overhead but is essential for running untrusted code. If code is trusted then metering maybe optional. Ewasm defines metering as an optional layer to accommodate for these use cases.
 * Furthermore some of Wasm's top [design goals](https://github.com/WebAssembly/design/blob/master/HighLevelGoals.md) are largely applicable to Ethereum  
 
 > Define a portable, size- and load-time-efficient binary format to serve as a compilation target which can be compiled to execute at native speed by taking advantage of common hardware capabilities available on a wide range of platforms, including mobile and IoT.

--- a/system_contracts.md
+++ b/system_contracts.md
@@ -1,10 +1,10 @@
 # System Contracts (Revision 0)
 
 System contracts are interfaces defined as contracts, which are essential or
-recommended for an eWASM VM.
+recommended for an ewasm VM.
 
-An eWASM VM implementation may opt to implement these interfaces natively
-or to rely on implementations written in eWASM.
+An ewasm VM implementation may opt to implement these interfaces natively
+or to rely on implementations written in ewasm.
 
 Each of these contracts have a pre defined address and can be executed through
 regular contract invocations.
@@ -13,24 +13,24 @@ regular contract invocations.
 
 Address: `0x000000000000000000000000000000000000000a`
 
-Every newly deployed eWASM contract must be processed by the *Sentinel Contract*
+Every newly deployed ewasm contract must be processed by the *Sentinel Contract*
 prior to including the code in the state. The sentinel will perform three very
 important processing steps:
-- Validate eWASM semantics
+- Validate ewasm semantics
 - Inject metering code
 - Wrap the result in the deployer preamble (*see Appendix A*)
 
 Input:
-- **variable length**: *eWASM contract code*
+- **variable length**: *ewasm contract code*
 
 Output:
-- **variable length**: *eWASM contract code*
+- **variable length**: *ewasm contract code*
 
 ## EVM Transcompiler
 
 Address: `0x000000000000000000000000000000000000000b`
 
-Transcompiles EVM1 bytecode into eWASM bytecode.
+Transcompiles EVM1 bytecode into ewasm bytecode.
 
 The use of this is optional. A compatible client may implement EVM1 natively or
 may choose to use this transcompiler.
@@ -39,14 +39,14 @@ Input:
 - **variable length**: *EVM1 contract code*
 
 Output:
-- **variable length**: *eWASM contract code*
+- **variable length**: *ewasm contract code*
 
 ## EVM Precompiled Contracts
 
 Precompiled contracts are defined for EVM1 (see the Yellow Paper). Several
 extensions have been proposed as *[Ethereum Improvement Proposals](http://github.com/ethereum/EIPs)*.
 
-We assume the contracts defined in the Yellow Paper still apply for eWASM.
+We assume the contracts defined in the Yellow Paper still apply for ewasm.
 
 ### ecrecover
 
@@ -111,11 +111,11 @@ Input:
 Output:
 - **32 bytes**: *keccak-256 hash*
 
-### Appendix A: eWASM deployer preamble
+### Appendix A: ewasm deployer preamble
 
 ```
 ;;
-;; Standard eWASM deployer code.
+;; Standard ewasm deployer code.
 ;;
 ;; We keep the to-be-deployed contract as a memory segment and simply return it.
 ;;

--- a/vm_semantics.md
+++ b/vm_semantics.md
@@ -4,10 +4,10 @@ We assume an existing Ethereum client (with EVM1) as the basis for extension.
 
 There are only 3 new rules:
 
-1. Whenever a contract is loaded from the state it must be checked for the eWASM signature.
+1. Whenever a contract is loaded from the state it must be checked for the ewasm signature.
 
-If the signature is present, it must be executed as an eWASM contract, otherwise it must be executed as an EVM1 contract.
+If the signature is present, it must be executed as an ewasm contract, otherwise it must be executed as an EVM1 contract.
 
 2. If there's no native EVM1 support in the client, it can use the *EVM Transcompiler* to translate the code.
 
-3. When deploying an eWASM contract, the bytecode must be verified and annotated by the *Sentinel Contract*.
+3. When deploying an ewasm contract, the bytecode must be verified and annotated by the *Sentinel Contract*.


### PR DESCRIPTION
As we have discussed, the styling of the name "eWASM" should be changed to "ewasm". The exception made here is in the cases when ewasm is used at the start of the sentence and when used in an acronym such as ECI, for which the first letter will be capitalized as with a normal word.