### PR TITLE
Rename getBalance to getExternalBalance

### DIFF
--- a/eth_interface.md
+++ b/eth_interface.md
@@ -42,7 +42,7 @@ the given offset.
 
 *nothing*
 
-## getBalance
+## getExternalBalance
 
 Gets balance of the given account and loads it into memory at the given
 offset.


### PR DESCRIPTION
It loads an external account and as such this naming reflects it better.