### PR TITLE
EEI: add isAccountEmpty method

### DIFF
--- a/eth_interface.md
+++ b/eth_interface.md
@@ -594,3 +594,20 @@ Get the block’s timestamp.
 **Returns**
 
 `blockTimestamp` **i64**
+
+## isAccountEmpty
+
+Returns 1 if account has no code, zero nonce and zero balance (as per [EIP-161](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)), and
+0 otherwise.
+
+**Parameters**
+
+-   `addressOffset` **i32ptr** the memory offset to load the address from (`address`)
+
+**Returns**
+
+`isEmpty` **i32**
+
+**Trap conditions**
+
+- load `address` from memory at `addressOffset` results in out of bounds access.


### PR DESCRIPTION
This method is required for metering `CALL` in runevm/evm2ewasm (#138 and https://github.com/axic/runevm/issues/18 for some context), and can also be used in implementing`EXTCODEHASH` (without adding an additional method to EEI).

I believe #112 could alternatively also solve this problem. I'm not sure however what's the consensus on that.