### PR TITLE
Remove revision number from top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Ethereum flavored WebAssembly (ewasm)
 
-Specification **Revision 4**
-
 This repository contains documents describing the design and high-level overview of ewasm. Expect the contents of this repository to be in flux: everything is still under discussion.
 
 **This repository is also available through [ReadTheDocs](https://ewasm.readthedocs.io).**


### PR DESCRIPTION
Nothing in this doc is versioned and it's confusing to lead with this. Let's just version the actual specification docs (https://github.com/ewasm/design/blob/master/contract_interface.md, https://github.com/ewasm/design/blob/master/eth_interface.md, https://github.com/ewasm/design/blob/master/system_contracts.md).