### PR TITLE
µs insted of us for a microsecond

### DIFF
--- a/determining_wasm_gas_costs.md
+++ b/determining_wasm_gas_costs.md
@@ -14,7 +14,7 @@ Ethereum nodes. We assume that a 2.2 Ghz model is the average.
 According to Intel, the 2.2 Ghz clock rate roughly equals to `2 200 000 000` cycles per second.
 
 **Assumption 2**: 1 second of CPU execution equals to 10 million gas
-(i.e. 1 gas equals to 0.1 us).
+(i.e. 1 gas equals to 0.1 µs).
 
 This equals to **`0.0045` gas per cycle**. (`10 000 000 / 2 200 000 000`)
 


### PR DESCRIPTION
The word us is confusing for a microsecond. So, we should use **µs** instead of **us** for a microsecond.